### PR TITLE
[WR-18897] bugfix(onboarding): harden .envrc adoption, prune broken VS Code extensions, quiet system_profiler

### DIFF
--- a/engineering/ide/.vscode/extensions_base.txt
+++ b/engineering/ide/.vscode/extensions_base.txt
@@ -9,7 +9,6 @@ esbenp.prettier-vscode
 foxundermoon.shell-format
 GitHub.codespaces
 GitHub.copilot
-GitHub.copilot-chat
 github.vscode-github-actions
 GitHub.vscode-pull-request-github
 HTMLHint.vscode-htmlhint
@@ -24,7 +23,6 @@ ms-playwright.playwright
 ms-vscode-remote.remote-containers
 ms-vscode-remote.remote-ssh
 ms-vscode-remote.remote-ssh-edit
-ms-vscode-remote.remote-wsl
 ms-vscode-remote.vscode-remote-extensionpack
 ms-vscode.remote-explorer
 ms-vscode.remote-server
@@ -36,7 +34,6 @@ richie5um2.vscode-sort-json
 ritwickdey.LiveServer
 ryu1kn.partial-diff
 steoates.autoimport
-stkb.rewrap
 streetsidesoftware.code-spell-checker
 stylelint.vscode-stylelint
 timonwong.shellcheck

--- a/onboarding_bin/onboard.sh
+++ b/onboarding_bin/onboard.sh
@@ -196,17 +196,23 @@ resolve_repo() {
 # ----------------------------------------------------------------------------
 # Step 6 — Machine variables (.envrc).  GATE only on first run (fill values).
 # ----------------------------------------------------------------------------
-ensure_envrc() {
-  step "Machine variables (.envrc)"
-  local target="$REPO_DIR/.envrc"
 
+# True when $1 sources cleanly. A malformed old-template file (e.g. a line like
+# `VAR=# Your key here` — `VAR=#` then `Your` is parsed as a command) emits
+# "command not found" to stderr; empty stderr means the file is safe to adopt.
+# Sourced in a throwaway subshell so it can't pollute our environment.
+envrc_is_sourceable() {
+  [[ -f "$1" ]] || return 1
+  local errout
+  errout="$(bash -c "source '$1'" 2>&1 >/dev/null)" || true
+  [[ -z "$errout" ]]
+}
+
+# Prompt for machine variables and write a clean .envrc to $1.
+generate_envrc() {
+  local target="$1"
   local pre="$REPO_DIR/onboarding_bin/pre-onboarding-script.sh"
-  if [[ -f "$target" ]]; then
-    ok ".envrc already present in repo"
-  elif [[ -f "$HOME/.envrc" ]]; then
-    mv "$HOME/.envrc" "$target"
-    ok "Moved ~/.envrc into the repo"
-  elif [[ -f "$pre" ]]; then
+  if [[ -f "$pre" ]]; then
     # Delegate to pre-onboarding-script.sh: it prompts for each value and writes
     # a clean, `export`-style ~/.envrc (no malformed placeholders). ONBOARD_ORCHESTRATED
     # tells it to skip its brew/clone tail (onboard.sh already did both). We feed
@@ -217,11 +223,11 @@ ensure_envrc() {
     else
       ONBOARD_ORCHESTRATED=1 bash "$pre" || warn "pre-onboarding-script.sh reported errors (review above)"
     fi
-    if [[ -f "$HOME/.envrc" ]]; then
+    if [[ -f "$HOME/.envrc" ]] && envrc_is_sourceable "$HOME/.envrc"; then
       mv "$HOME/.envrc" "$target"
       ok ".envrc generated and saved into the repo"
     else
-      warn "~/.envrc was not created — falling back to the template"
+      warn "~/.envrc was not created cleanly — falling back to the template"
       cp "$REPO_DIR/.envrc.example" "$target"
       "${EDITOR:-open}" "$target" >/dev/null 2>&1 || open "$target" 2>/dev/null || true
       ask _ "   Press Enter once you've saved your values in .envrc... "
@@ -232,6 +238,36 @@ ensure_envrc() {
     "${EDITOR:-open}" "$target" >/dev/null 2>&1 || open "$target" 2>/dev/null || true
     ask _ "   Press Enter once you've saved your values in .envrc... "
     ok ".envrc ready"
+  fi
+}
+
+ensure_envrc() {
+  step "Machine variables (.envrc)"
+  local target="$REPO_DIR/.envrc"
+
+  # Only adopt an existing .envrc if it actually sources cleanly. Otherwise an
+  # old-template copy (malformed `VAR=# ...` lines, placeholder values) gets
+  # silently adopted, the prompt is skipped, and every new shell spews
+  # "command not found" while aliases resolve to bogus placeholder paths.
+  if [[ -f "$target" ]]; then
+    if envrc_is_sourceable "$target"; then
+      ok ".envrc already present in repo"
+    else
+      warn "Repo .envrc is malformed (old template?) — backing up to .envrc.malformed.bak and regenerating"
+      mv "$target" "$target.malformed.bak"
+      generate_envrc "$target"
+    fi
+  elif [[ -f "$HOME/.envrc" ]]; then
+    if envrc_is_sourceable "$HOME/.envrc"; then
+      mv "$HOME/.envrc" "$target"
+      ok "Moved ~/.envrc into the repo"
+    else
+      warn "Existing ~/.envrc is malformed (old template?) — backing up to ~/.envrc.malformed.bak and regenerating"
+      mv "$HOME/.envrc" "$HOME/.envrc.malformed.bak"
+      generate_envrc "$target"
+    fi
+  else
+    generate_envrc "$target"
   fi
 
   # Load values into THIS session so later steps (company path, keys) see them.

--- a/shell/starship.zsh
+++ b/shell/starship.zsh
@@ -6,8 +6,11 @@ if [[ -f $LFILE ]]; then
 elif [[ -f $MFILE ]]; then
   _distro="macos"
 
-  # on mac os use the systemprofiler to determine the current model
-  _device=$(system_profiler SPHardwareDataType | awk '/Model Name/ {print $3,$4,$5,$6,$7}')
+  # on mac os use the systemprofiler to determine the current model.
+  # 2>/dev/null: on some Macs system_profiler prints a diagnostic line
+  # (e.g. "hw.cpufamily: 0x...") to stderr that would otherwise leak into
+  # every new shell. We only want stdout ("Model Name") for the icon match.
+  _device=$(system_profiler SPHardwareDataType 2>/dev/null | awk '/Model Name/ {print $3,$4,$5,$6,$7}')
 
   case $_device in
   *MacBook*) DEVICE="" ;;


### PR DESCRIPTION
## Summary

Follow-on fixes from the Mac Mini provisioning review. Tracked under [WR-18897](https://bydesign.atlassian.net/browse/WR-18897); companion to the validation ticket WR-18887.

- **`onboard.sh` — validate `.envrc` before adopting it.** Adds `envrc_is_sourceable()` (sources the file in a throwaway subshell; non-empty stderr ⇒ malformed) and extracts the prompt flow into `generate_envrc()`. A malformed/old-template `.envrc` (e.g. `VAR=# comment` lines) is now backed up to `*.malformed.bak` and regenerated instead of being silently moved into the repo. This was the root cause of a fresh machine getting an old-template `.envrc` that spammed `command not found` on every shell and left aliases pointing at bogus placeholder paths — with the prompt never shown.
- **`extensions_base.txt` — remove three problem extensions.** `GitHub.copilot-chat` (now a **built-in** extension; install conflicts/downgrade error), `stkb.rewrap` (fails marketplace **signature verification** — `NotSigned`), and `ms-vscode-remote.remote-wsl` (Windows-only, no-op on macOS). 42 extensions remain.
- **`starship.zsh` — silence `system_profiler` stderr.** Adds `2>/dev/null` so its `hw.cpufamily: 0x…` diagnostic stops leaking into every new shell. Kept `system_profiler` (not `sysctl hw.model`) because the prompt-icon `case` depends on the human-readable "Model Name".

## Test plan

- [x] `bash -n onboarding_bin/onboard.sh` and `zsh -n shell/starship.zsh` pass.
- [x] `envrc_is_sourceable` rejects the old-template `VAR=# …` line and accepts a clean `export`-style file (verified locally).
- [ ] Re-run `onboard.sh` on the Mac Mini: malformed `~/.envrc` is backed up and regenerated; clean file is adopted.
- [ ] `code --install-extension` pass over `extensions_base.txt` completes with no signature/built-in errors.
- [ ] Open a new shell: no `system_profiler` line, correct prompt device icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden onboarding environment setup and shell prompt behavior while pruning problematic VS Code extensions.

Bug Fixes:
- Validate .envrc files before adopting them, backing up malformed or legacy copies and regenerating a clean version to avoid broken shells and skipped prompts.
- Silence spurious system_profiler diagnostics from the shell prompt so they no longer appear in every new macOS shell.

Enhancements:
- Factor .envrc generation into a dedicated helper to centralize the machine-variable prompt and file creation flow.