### PR TITLE
maintenance(shell): guard against unwritable inherited TMPDIR in headless contexts

### DIFF
--- a/shell/.zprofile
+++ b/shell/.zprofile
@@ -4,6 +4,18 @@
 if [ -r "/opt/homebrew/bin/brew" ]; then
   eval $(/opt/homebrew/bin/brew shellenv)
 fi
+
+# Ensure a writable temp dir. Headless / launchd-launched contexts inherit the
+# root-owned macOS fallback (TMPDIR=/var/folders/zz/.../T, mode 0700), which is
+# unwritable by the user and breaks vitest/npm/esbuild with EACCES. Only override
+# when TMPDIR is unset or not writable, so interactive machines keep system temp.
+if [ -z "$TMPDIR" ] || [ ! -w "${TMPDIR%/}" ]; then
+  export TMPDIR="$HOME/.claude/tmp"
+  export TMP="$TMPDIR"
+  export TEMP="$TMPDIR"
+  mkdir -p "$TMPDIR"
+fi
+
 if [[ $- == *i* ]] && [ -t 0 ]; then
   echo "This is an interactive shell"
 else


### PR DESCRIPTION
## Problem

The 24/7 headless Mac mini agent (and any launchd-launched shell) inherits the **generic macOS fallback** temp dir:

```
TMPDIR=/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T   # owned root:wheel, mode 0700
```

instead of the per-user temp — because a launchd-less/headless context never sets up the `DARWIN_USER_TEMP_DIR` bootstrap. That directory is **not writable** by the user, so any tool that writes to `$TMPDIR` fails with `EACCES`:

- `vitest run` — its coverage provider `mkdir`s a working dir under `$TMPDIR`
- `npm`, `esbuild`, and other temp-writing tooling, intermittently

It is **not** a sandbox/permissions issue — the bad `TMPDIR` is inherited from the launch environment.

## Fix

Add a guard to `shell/.zprofile` that repoints `TMPDIR`/`TMP`/`TEMP` at `~/.claude/tmp` **only when** the inherited value is unset or not writable. Healthy interactive machines (which get a proper writable per-user temp) are left untouched.

```sh
if [ -z "$TMPDIR" ] || [ ! -w "${TMPDIR%/}" ]; then
  export TMPDIR="$HOME/.claude/tmp"
  export TMP="$TMPDIR"
  export TEMP="$TMPDIR"
  mkdir -p "$TMPDIR"
fi
```

## Testing

- `bash -n` and `zsh -n` pass.
- Guard verified across states: unset → override; root-owned `zz` fallback → override; writable dir / real per-user temp → keep system temp.

Relates to the Mac mini agent hardening (WR-18897). Claude Code itself is already covered live via `env.TMPDIR` in `~/.claude/settings.json`; this extends the fix to the whole shell-launched agent context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add a zprofile guard that rewrites TMPDIR/TMP/TEMP to a per-user temp directory when the inherited TMPDIR is unset or not writable to prevent EACCES failures in headless environments.